### PR TITLE
don't send new watch command before poling

### DIFF
--- a/lib/gpsd_client.rb
+++ b/lib/gpsd_client.rb
@@ -35,11 +35,11 @@ module GpsdClient
         end
         return @started
     end
-    
+
     def started?
         @started
     end
-    
+
     def stop
         return not_started_msg("Gpsd.stop") if not self.started?
         @socket.puts '?WATCH={"enable":false};'
@@ -47,12 +47,12 @@ module GpsdClient
         @started = false if @socket.closed?
         !self.started?
     end
-    
+
     def get_position
         reads = 0
         empty_hash =  {lat: nil, lon: nil, time: nil, speed: nil, altitude: nil }
         return empty_hash if not self.started?
-        
+
         while reads < 10 do # Skip VERSION SKY WATCH or DEVICES response
             line = ""
             begin
@@ -63,7 +63,7 @@ module GpsdClient
             rescue Exception => ex
                 puts "Error while reading Socket: #{ex.message}"
             end
-        
+
             # Parse line, return empty string on fail
             # if parsed, extract ptv Hash from the JSON report polled
             line = JSON.parse(line) rescue ''
@@ -78,20 +78,20 @@ module GpsdClient
                 # return "Lat: #{line['lat'].to_s}, Lon: #{line['lon'].to_s}" unless line['mode'] == 1
                 return {lat: line['lat'], lon: line['lon'], time: line['time'], speed: line['speed'], altitude: line['alt']} unless line['mode'] == 1
             end
-            
+
             reads = reads + 1
-        
+
         end
         #puts "debug >> TPV not found polling on GPSd"
         return empty_hash
     end
-    
+
     private
-    
+
     def not_started_msg( method = 'Gpsd' )
         puts "#{method}: No socket connection started"
         return nil
     end
-    
+
   end
 end


### PR DESCRIPTION
Since we already started the watch with gpsd_client.start there is no need to issue a new ?WATCH command to create a new listener when .get_position was called.
The issue that occurs here is that each watch creates a couple of lines followed by poll which again creates a line.
gets only reads one line at a time, leaving data on the socket which was no read.
If sleeping for let's say 10 sec, a poll will deliver data from 10 sec ago.
After some time the data on the socket adds up and the client crashes.
