### PR TITLE
return all available attributes

### DIFF
--- a/lib/gpsd_client.rb
+++ b/lib/gpsd_client.rb
@@ -84,7 +84,7 @@ module GpsdClient
                 # mode 1 means no valid data
                 # return "Lat: #{line['lat'].to_s}, Lon: #{line['lon'].to_s}" unless line['mode'] == 1
                 flush_socket
-                return {lat: line['lat'], lon: line['lon'], time: line['time'], speed: line['speed'], altitude: line['alt']} unless line['mode'] == 1
+                return line.symbolize_keys unless line['mode'] == 1
             end
             #puts "debug >> TPV not found polling on GPSd"
         end

--- a/lib/gpsd_client/version.rb
+++ b/lib/gpsd_client/version.rb
@@ -1,3 +1,3 @@
 module GpsdClient
-  VERSION = "0.0.5"
+  VERSION = "0.0.6"
 end


### PR DESCRIPTION
gpsd returns lots of attibutes that are not available in the get_position return value.  This change will return the entire TPV record.